### PR TITLE
Add Bambi Scripts and Chocolatey Packaging

### DIFF
--- a/Builds/Chocolatey/bamboo-tray.nuspec
+++ b/Builds/Chocolatey/bamboo-tray.nuspec
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>bamboo-tray.portable</id>
+    <version>$version$</version>
+    <title>Bamboo Tray</title>
+    <authors>Tom Hall, Kevin Ortman</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectUrl>https://github.com/KevinOrtman/bambootray</projectUrl>
+    <description>CCTray-like interface for Atlassian Bamboo </description>
+  </metadata>
+  <files>
+    <file src="..\..\BambooTray.App\bin\Debug\**" target="tools" />
+    <file src="chocolateyInstall.ps1" target="tools" />
+    <file src="chocolateyUninstall.ps1" target="tools" />
+  </files>
+</package>

--- a/Builds/Chocolatey/chocolateyInstall.ps1
+++ b/Builds/Chocolatey/chocolateyInstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-ChocolateySuccess "bamboo-tray.portable"

--- a/Builds/Chocolatey/chocolateyUninstall.ps1
+++ b/Builds/Chocolatey/chocolateyUninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-ChocolateySuccess "bamboo-tray.portable"

--- a/Builds/build.build
+++ b/Builds/build.build
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project name="Build" default="run" basedir=".."
+         xmlns="http://nant.sf.net/release/0.92/nant.xsd">
+  
+  <loadtasks assembly="C:\Program Files\CSG\DevTools\Lib\NAnt\Dev.NAnt.Tasks.dll" />
+  
+  <target name="run">
+    <initproperty name="csg.oss.chocolatey.apikey" default="286c8b76-b210-3379-becf-b6dd80b9c3ed" />
+    <initproperty name="csg.oss.chocolatey.source" default="http://10.99.37.7:8081/nexus/service/local/nuget/csg.oss.chocolatey" />
+  
+    <nuget action="restore" />
+    <msbuild project="BambooTray.sln" />
+    
+    <chocopack nuspec="Builds\Chocolatey\bamboo-tray.nuspec" version="1.0.0.3" feed="csg.oss.chocolatey" />
+    <chocopush nupkgdir="Artifacts\Publish\csg.oss.chocolatey" apikey="${csg.oss.chocolatey.apikey}" source="${csg.oss.chocolatey.source}" />
+  </target>
+
+</project>


### PR DESCRIPTION
I have added scripts to make it easy to run this on our Bambi CI system.

Also I made a stub Chocolatey package (bamboo-tray.portable) which is publishing to a test server. 
* Once we have a final location (e.g. chocolatey.org), I'll update the creds and remove them from the script.
* It would be neat to create an internal package which configures it to monitor our builds and automatically start with Windows.
* This doesn't distribute Bamboo Tray like the original, i.e. all the dependencies built into the exe.