### PR TITLE
Publish to chocolatey.org

### DIFF
--- a/Builds/build.build
+++ b/Builds/build.build
@@ -5,14 +5,10 @@
   <loadtasks assembly="C:\Program Files\CSG\DevTools\Lib\NAnt\Dev.NAnt.Tasks.dll" />
   
   <target name="run">
-    <initproperty name="csg.oss.chocolatey.apikey" default="286c8b76-b210-3379-becf-b6dd80b9c3ed" />
-    <initproperty name="csg.oss.chocolatey.source" default="http://10.99.37.7:8081/nexus/service/local/nuget/csg.oss.chocolatey" />
-  
     <nuget action="restore" />
     <msbuild project="BambooTray.sln" />
     
-    <chocopack nuspec="Builds\Chocolatey\bamboo-tray.nuspec" version="1.0.0.3" feed="csg.oss.chocolatey" />
-    <chocopush nupkgdir="Artifacts\Publish\csg.oss.chocolatey" apikey="${csg.oss.chocolatey.apikey}" source="${csg.oss.chocolatey.source}" />
+    <chocopack nuspec="Builds\Chocolatey\bamboo-tray.nuspec" version="1.0.0.3" feed="chocolatey.org" />
   </target>
 
 </project>

--- a/Builds/init-properties.include
+++ b/Builds/init-properties.include
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<project name="Initialize Properties" basedir="." xmlns="http://nant.sf.net/release/0.92/nant.xsd">
+
+  <property name="build.branch.default" value="master" />
+
+</project>


### PR DESCRIPTION
Publish all successful builds on master to chocolatey.org using the credentials configured in Bamboo for the Bamboo Tray plan.

FYI, each open source build which publishes to a public repo (chocolatey.org/nuget.org) must be configured with the credentials to use, so that we never accidentally reuse someone's credentials.