### PR TITLE
Updated the plan description in the grid and added browser launch

### DIFF
--- a/BambooTray.App/MainWindow.Designer.cs
+++ b/BambooTray.App/MainWindow.Designer.cs
@@ -136,16 +136,17 @@ namespace BambooTray.App
             // serverColumnHeader
             // 
             this.serverColumnHeader.Text = "Server";
-            this.serverColumnHeader.Width = 100;
+            this.serverColumnHeader.Width = 80;
             // 
             // projectColumnHeader
             // 
             this.projectColumnHeader.Text = "Project";
-            this.projectColumnHeader.Width = 100;
+            this.projectColumnHeader.Width = 74;
             // 
             // planColumnHeader
             // 
             this.planColumnHeader.Text = "Plan";
+            this.planColumnHeader.Width = 119;
             // 
             // buildActivityColumnHeader
             // 

--- a/BambooTray.App/MainWindow.Designer.cs
+++ b/BambooTray.App/MainWindow.Designer.cs
@@ -30,202 +30,203 @@ namespace BambooTray.App
         /// </summary>
         private void InitializeComponent()
         {
-            components = new System.ComponentModel.Container();
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainWindow));
-            menuStrip1 = new System.Windows.Forms.MenuStrip();
-            fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            preferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            buildsListView = new System.Windows.Forms.ListView();
-            serverColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            projectColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            planColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            buildActivityColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            buildStatusColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            lastBuildTimeColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            lastBuildDurationColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            lastBuildNumberColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            lastVcsRevisionColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            successfulTestCountColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            failedTestCountColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            notifyIcon = new System.Windows.Forms.NotifyIcon(components);
-            updateTimer = new System.Windows.Forms.Timer(components);
-            iconTimer = new System.Windows.Forms.Timer(components);
-            mainViewModelBindingSource = new System.Windows.Forms.BindingSource(components);
-            menuStrip1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(mainViewModelBindingSource)).BeginInit();
-            SuspendLayout();
+            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.preferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.buildsListView = new System.Windows.Forms.ListView();
+            this.serverColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.projectColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.planColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.buildActivityColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.buildStatusColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lastBuildTimeColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lastBuildDurationColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lastBuildNumberColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.lastVcsRevisionColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.successfulTestCountColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.failedTestCountColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
+            this.updateTimer = new System.Windows.Forms.Timer(this.components);
+            this.iconTimer = new System.Windows.Forms.Timer(this.components);
+            this.mainViewModelBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.menuStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.mainViewModelBindingSource)).BeginInit();
+            this.SuspendLayout();
             // 
             // menuStrip1
             // 
-            menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            fileToolStripMenuItem,
-            helpToolStripMenuItem});
-            menuStrip1.Location = new System.Drawing.Point(0, 0);
-            menuStrip1.Name = "menuStrip1";
-            menuStrip1.Size = new System.Drawing.Size(896, 24);
-            menuStrip1.TabIndex = 2;
-            menuStrip1.Text = "menuStrip1";
+            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.fileToolStripMenuItem,
+            this.helpToolStripMenuItem});
+            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+            this.menuStrip1.Name = "menuStrip1";
+            this.menuStrip1.Size = new System.Drawing.Size(896, 24);
+            this.menuStrip1.TabIndex = 2;
+            this.menuStrip1.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
-            fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            preferencesToolStripMenuItem,
-            exitToolStripMenuItem});
-            fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-            fileToolStripMenuItem.Text = "&File";
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.preferencesToolStripMenuItem,
+            this.exitToolStripMenuItem});
+            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Text = "&File";
             // 
             // preferencesToolStripMenuItem
             // 
-            preferencesToolStripMenuItem.Name = "preferencesToolStripMenuItem";
-            preferencesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
-            preferencesToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
-            preferencesToolStripMenuItem.Text = "&Preferences...";
-            preferencesToolStripMenuItem.Click += new System.EventHandler(PreferencesToolStripMenuItemClick);
+            this.preferencesToolStripMenuItem.Name = "preferencesToolStripMenuItem";
+            this.preferencesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
+            this.preferencesToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
+            this.preferencesToolStripMenuItem.Text = "&Preferences...";
+            this.preferencesToolStripMenuItem.Click += new System.EventHandler(this.PreferencesToolStripMenuItemClick);
             // 
             // exitToolStripMenuItem
             // 
-            exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
-            exitToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
-            exitToolStripMenuItem.Text = "E&xit";
-            exitToolStripMenuItem.Click += new System.EventHandler(ExitToolStripMenuItemClick);
+            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F4)));
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
+            this.exitToolStripMenuItem.Text = "E&xit";
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitToolStripMenuItemClick);
             // 
             // helpToolStripMenuItem
             // 
-            helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            aboutToolStripMenuItem});
-            helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-            helpToolStripMenuItem.Text = "&Help";
+            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.aboutToolStripMenuItem});
+            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpToolStripMenuItem.Text = "&Help";
             // 
             // aboutToolStripMenuItem
             // 
-            aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            aboutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
-            aboutToolStripMenuItem.Text = "&About";
-            aboutToolStripMenuItem.Click += new System.EventHandler(AboutToolStripMenuItemClick);
+            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.aboutToolStripMenuItem.Text = "&About";
+            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.AboutToolStripMenuItemClick);
             // 
             // buildsListView
             // 
-            buildsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            serverColumnHeader,
-            projectColumnHeader,
-            planColumnHeader,
-            buildActivityColumnHeader,
-            buildStatusColumnHeader,
-            lastBuildTimeColumnHeader,
-            lastBuildDurationColumnHeader,
-            lastBuildNumberColumnHeader,
-            lastVcsRevisionColumnHeader,
-            successfulTestCountColumnHeader,
-            failedTestCountColumnHeader});
-            buildsListView.Dock = System.Windows.Forms.DockStyle.Fill;
-            buildsListView.FullRowSelect = true;
-            buildsListView.Location = new System.Drawing.Point(0, 24);
-            buildsListView.Name = "buildsListView";
-            buildsListView.Size = new System.Drawing.Size(896, 200);
-            buildsListView.TabIndex = 3;
-            buildsListView.UseCompatibleStateImageBehavior = false;
-            buildsListView.View = System.Windows.Forms.View.Details;
+            this.buildsListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.serverColumnHeader,
+            this.projectColumnHeader,
+            this.planColumnHeader,
+            this.buildActivityColumnHeader,
+            this.buildStatusColumnHeader,
+            this.lastBuildTimeColumnHeader,
+            this.lastBuildDurationColumnHeader,
+            this.lastBuildNumberColumnHeader,
+            this.lastVcsRevisionColumnHeader,
+            this.successfulTestCountColumnHeader,
+            this.failedTestCountColumnHeader});
+            this.buildsListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.buildsListView.FullRowSelect = true;
+            this.buildsListView.Location = new System.Drawing.Point(0, 24);
+            this.buildsListView.Name = "buildsListView";
+            this.buildsListView.Size = new System.Drawing.Size(896, 200);
+            this.buildsListView.TabIndex = 3;
+            this.buildsListView.UseCompatibleStateImageBehavior = false;
+            this.buildsListView.View = System.Windows.Forms.View.Details;
+            this.buildsListView.DoubleClick += new System.EventHandler(this.ListViewDoubleClick);
             // 
             // serverColumnHeader
             // 
-            serverColumnHeader.Text = "Server";
-            serverColumnHeader.Width = 100;
+            this.serverColumnHeader.Text = "Server";
+            this.serverColumnHeader.Width = 100;
             // 
             // projectColumnHeader
             // 
-            projectColumnHeader.Text = "Project";
-            projectColumnHeader.Width = 100;
+            this.projectColumnHeader.Text = "Project";
+            this.projectColumnHeader.Width = 100;
             // 
             // planColumnHeader
             // 
-            planColumnHeader.Text = "Plan";
+            this.planColumnHeader.Text = "Plan";
             // 
             // buildActivityColumnHeader
             // 
-            buildActivityColumnHeader.Text = "Activity";
+            this.buildActivityColumnHeader.Text = "Activity";
             // 
             // buildStatusColumnHeader
             // 
-            buildStatusColumnHeader.Text = "Status";
-            buildStatusColumnHeader.Width = 70;
+            this.buildStatusColumnHeader.Text = "Status";
+            this.buildStatusColumnHeader.Width = 70;
             // 
             // lastBuildTimeColumnHeader
             // 
-            lastBuildTimeColumnHeader.Text = "Last Build";
-            lastBuildTimeColumnHeader.Width = 85;
+            this.lastBuildTimeColumnHeader.Text = "Last Build";
+            this.lastBuildTimeColumnHeader.Width = 85;
             // 
             // lastBuildDurationColumnHeader
             // 
-            lastBuildDurationColumnHeader.Text = "Duration";
-            lastBuildDurationColumnHeader.Width = 80;
+            this.lastBuildDurationColumnHeader.Text = "Duration";
+            this.lastBuildDurationColumnHeader.Width = 80;
             // 
             // lastBuildNumberColumnHeader
             // 
-            lastBuildNumberColumnHeader.Text = "Build Number";
-            lastBuildNumberColumnHeader.Width = 80;
+            this.lastBuildNumberColumnHeader.Text = "Build Number";
+            this.lastBuildNumberColumnHeader.Width = 80;
             // 
             // lastVcsRevisionColumnHeader
             // 
-            lastVcsRevisionColumnHeader.Text = "VCS Revision";
-            lastVcsRevisionColumnHeader.Width = 80;
+            this.lastVcsRevisionColumnHeader.Text = "VCS Revision";
+            this.lastVcsRevisionColumnHeader.Width = 80;
             // 
             // successfulTestCountColumnHeader
             // 
-            successfulTestCountColumnHeader.Text = "Passing Tests";
-            successfulTestCountColumnHeader.Width = 80;
+            this.successfulTestCountColumnHeader.Text = "Passing Tests";
+            this.successfulTestCountColumnHeader.Width = 80;
             // 
             // failedTestCountColumnHeader
             // 
-            failedTestCountColumnHeader.Text = "Failing Tests";
-            failedTestCountColumnHeader.Width = 80;
+            this.failedTestCountColumnHeader.Text = "Failing Tests";
+            this.failedTestCountColumnHeader.Width = 80;
             // 
             // notifyIcon
             // 
-            notifyIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIcon.Icon")));
-            notifyIcon.Text = "Bamboo Tray";
-            notifyIcon.Visible = true;
-            notifyIcon.Click += new System.EventHandler(NotifyIconClick);
+            this.notifyIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIcon.Icon")));
+            this.notifyIcon.Text = "Bamboo Tray";
+            this.notifyIcon.Visible = true;
+            this.notifyIcon.Click += new System.EventHandler(this.NotifyIconClick);
             // 
             // updateTimer
             // 
-            updateTimer.Enabled = true;
-            updateTimer.Interval = 20000;
-            updateTimer.Tick += new System.EventHandler(UpdateTimerTick);
+            this.updateTimer.Enabled = true;
+            this.updateTimer.Interval = 20000;
+            this.updateTimer.Tick += new System.EventHandler(this.UpdateTimerTick);
             // 
             // iconTimer
             // 
-            iconTimer.Interval = 200;
-            iconTimer.Tick += new System.EventHandler(BuildIconTimerTick);
+            this.iconTimer.Interval = 200;
+            this.iconTimer.Tick += new System.EventHandler(this.BuildIconTimerTick);
             // 
             // mainViewModelBindingSource
             // 
-            mainViewModelBindingSource.DataSource = typeof(MainViewModel);
+            this.mainViewModelBindingSource.DataSource = typeof(BambooTray.App.Models.MainViewModel);
             // 
             // MainWindow
             // 
-            AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(896, 224);
-            Controls.Add(buildsListView);
-            Controls.Add(menuStrip1);
-            Icon = ((System.Drawing.Icon)(resources.GetObject("$Icon")));
-            MainMenuStrip = menuStrip1;
-            MaximizeBox = false;
-            MinimizeBox = false;
-            Name = "MainWindow";
-            Text = "Bamboo Tray";
-            FormClosing += new System.Windows.Forms.FormClosingEventHandler(MainFormClosing);
-            menuStrip1.ResumeLayout(false);
-            menuStrip1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(mainViewModelBindingSource)).EndInit();
-            ResumeLayout(false);
-            PerformLayout();
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(896, 224);
+            this.Controls.Add(this.buildsListView);
+            this.Controls.Add(this.menuStrip1);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MainMenuStrip = this.menuStrip1;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "MainWindow";
+            this.Text = "Bamboo Tray";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainFormClosing);
+            this.menuStrip1.ResumeLayout(false);
+            this.menuStrip1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.mainViewModelBindingSource)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 

--- a/BambooTray.App/MainWindow.Designer.cs
+++ b/BambooTray.App/MainWindow.Designer.cs
@@ -51,10 +51,13 @@ namespace BambooTray.App
             this.successfulTestCountColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.failedTestCountColumnHeader = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.notifyIcon = new System.Windows.Forms.NotifyIcon(this.components);
+            this.contextMenuTray = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.menuItemExit = new System.Windows.Forms.ToolStripMenuItem();
             this.updateTimer = new System.Windows.Forms.Timer(this.components);
             this.iconTimer = new System.Windows.Forms.Timer(this.components);
             this.mainViewModelBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.menuStrip1.SuspendLayout();
+            this.contextMenuTray.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.mainViewModelBindingSource)).BeginInit();
             this.SuspendLayout();
             // 
@@ -189,10 +192,25 @@ namespace BambooTray.App
             // 
             // notifyIcon
             // 
+            this.notifyIcon.ContextMenuStrip = this.contextMenuTray;
             this.notifyIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("notifyIcon.Icon")));
             this.notifyIcon.Text = "Bamboo Tray";
             this.notifyIcon.Visible = true;
-            this.notifyIcon.Click += new System.EventHandler(this.NotifyIconClick);
+            this.notifyIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.NotifyIconClick);
+            // 
+            // contextMenuTray
+            // 
+            this.contextMenuTray.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.menuItemExit});
+            this.contextMenuTray.Name = "contextMenuTray";
+            this.contextMenuTray.Size = new System.Drawing.Size(93, 26);
+            // 
+            // menuItemExit
+            // 
+            this.menuItemExit.Name = "menuItemExit";
+            this.menuItemExit.Size = new System.Drawing.Size(92, 22);
+            this.menuItemExit.Text = "E&xit";
+            this.menuItemExit.Click += new System.EventHandler(this.ExitToolStripMenuItemClick);
             // 
             // updateTimer
             // 
@@ -222,9 +240,9 @@ namespace BambooTray.App
             this.MinimizeBox = false;
             this.Name = "MainWindow";
             this.Text = "Bamboo Tray";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainFormClosing);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
+            this.contextMenuTray.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.mainViewModelBindingSource)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -255,6 +273,8 @@ namespace BambooTray.App
         private System.Windows.Forms.Timer updateTimer;
         private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
         private System.Windows.Forms.Timer iconTimer;
+        private System.Windows.Forms.ContextMenuStrip contextMenuTray;
+        private System.Windows.Forms.ToolStripMenuItem menuItemExit;
     }
 }
 

--- a/BambooTray.App/MainWindow.cs
+++ b/BambooTray.App/MainWindow.cs
@@ -60,8 +60,8 @@ namespace BambooTray.App
 
             _lastBuildData = new List<MainViewModel>();
             buildsListView.SmallImageList = GetListViewImages();
-            updateTimer.Interval = Settings.PollTime;
             RefreshBuilds();
+            RestartTimer();
         }
 
         private TraySettings Settings
@@ -172,6 +172,9 @@ namespace BambooTray.App
 
         private void DoNotifications(IEnumerable<MainViewModel> currentBuildData)
         {
+            if (!_settingsService.TraySettings.EnableBaloonNotifications)
+                return;
+
             foreach (var currentBuild in currentBuildData)
             {
                 var lastBuild = _lastBuildData.FirstOrDefault(x => x.PlanKey == currentBuild.PlanKey);
@@ -281,6 +284,14 @@ namespace BambooTray.App
             // Open the Preferences Window
             var preferencesWindow = new PreferencesWindow(_settingsService);
             preferencesWindow.ShowDialog(this);
+            RestartTimer();
+        }
+
+        private void RestartTimer()
+        {
+            updateTimer.Stop();
+            updateTimer.Interval = _settingsService.TraySettings.PollTime;
+            updateTimer.Start();
         }
 
         private void AboutToolStripMenuItemClick(object sender, EventArgs e)

--- a/BambooTray.App/MainWindow.cs
+++ b/BambooTray.App/MainWindow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -227,7 +228,7 @@ namespace BambooTray.App
                             : (string.IsNullOrEmpty(p.BuildStatus) ? "Offline" : p.BuildStatus)
                 };
                 lv.SubItems.Add(p.ProjectName);
-                lv.SubItems.Add(string.Format("{0}  ({1})", p.PlanName, p.PlanKey));
+                lv.SubItems.Add(new ListViewItem.ListViewSubItem() { Text = string.Format("{0}  ({1})", p.ShortPlanName, p.PlanKey), Tag = p.PlanKey});
                 lv.SubItems.Add(p.BuildActivity);
                 lv.SubItems.Add(p.BuildStatus);
                 lv.SubItems.Add(p.LastBuildTime);
@@ -237,6 +238,40 @@ namespace BambooTray.App
                 lv.SubItems.Add(p.SuccessfulTestCount);
                 lv.SubItems.Add(p.FailedTestCount);
                 buildsListView.Items.Add(lv);
+            }
+        }
+
+        private void ListViewDoubleClick(object sender, EventArgs e)
+        {
+            if (buildsListView.SelectedItems.Count > 0 && buildsListView.SelectedItems[0].SubItems.Count > 3)
+            {
+                var listViewSubItem = buildsListView.SelectedItems[0].SubItems[2];
+
+                if (listViewSubItem != null && listViewSubItem.Tag != null)
+                {
+                    var planKey = listViewSubItem.Tag.ToString();
+                    var buildData = _lastBuildData ?? new List<MainViewModel>();
+                    var buildDatum = buildData.FirstOrDefault(d => d.PlanKey == planKey);
+
+                    if (buildDatum != null)
+                    {
+                        LaunchBrowser(buildDatum.LatestResultUrl);
+                    }
+                }
+            }
+            
+        }
+
+        private void LaunchBrowser(string url)
+        {
+            try
+            {
+                Process.Start(url);
+            }
+            catch (Exception e)
+            {
+                string msg = string.Format("Unable to view the web page.{0}{0}{1}", Environment.NewLine, e.Message);
+                MessageBox.Show(msg, "Unable to Launch Browser", MessageBoxButtons.OK);
             }
         }
 

--- a/BambooTray.App/MainWindow.cs
+++ b/BambooTray.App/MainWindow.cs
@@ -136,11 +136,14 @@ namespace BambooTray.App
 
         private void RefreshBuilds()
         {
-            var plans = new List<MainViewModel>();
+            using (new PreserveSelectedItemGuard(buildsListView))
+            {
+                var plans = new List<MainViewModel>();
 
-            buildsListView.Items.Clear();
-            foreach (var server in Settings.Servers.Where(server => server.BuildPlans.Count > 0))
-                RefreshServerBuild(server, plans);
+                buildsListView.Items.Clear();
+                foreach (var server in Settings.Servers.Where(server => server.BuildPlans.Count > 0))
+                    RefreshServerBuild(server, plans);
+            }
         }
 
         private void UpdateTrayIcon(IEnumerable<MainViewModel> currentBuildData)
@@ -214,49 +217,47 @@ namespace BambooTray.App
             }
         }
 
-        private void GetPlansListViewData(IEnumerable<MainViewModel> currentBuildData)
+        private void GetPlansListViewData(IEnumerable<MainViewModel> mainViewModels)
         {
             buildsListView.Items.Clear();
-            foreach (var p in currentBuildData)
+            foreach (var mainViewModel in mainViewModels)
             {
                 var lv = new ListViewItem
                 {
-                    Text = p.ServerName,
+                    Text = mainViewModel.ServerName,
+                    Tag = mainViewModel,
                     ImageKey =
-                        p.BuildActivity == "Building"
-                            ? p.BuildActivity
-                            : (string.IsNullOrEmpty(p.BuildStatus) ? "Offline" : p.BuildStatus)
+                        mainViewModel.BuildActivity == "Building"
+                            ? mainViewModel.BuildActivity
+                            : (string.IsNullOrEmpty(mainViewModel.BuildStatus) ? "Offline" : mainViewModel.BuildStatus)
                 };
-                lv.SubItems.Add(p.ProjectName);
-                lv.SubItems.Add(new ListViewItem.ListViewSubItem() { Text = string.Format("{0}  ({1})", p.ShortPlanName, p.PlanKey), Tag = p.PlanKey});
-                lv.SubItems.Add(p.BuildActivity);
-                lv.SubItems.Add(p.BuildStatus);
-                lv.SubItems.Add(p.LastBuildTime);
-                lv.SubItems.Add(p.LastBuildDuration);
-                lv.SubItems.Add(p.LastBuildNumber);
-                lv.SubItems.Add(p.LastVcsRevision);
-                lv.SubItems.Add(p.SuccessfulTestCount);
-                lv.SubItems.Add(p.FailedTestCount);
+
+                lv.SubItems.Add(mainViewModel.ProjectName);
+                lv.SubItems.Add(string.Format("{0}  ({1})", mainViewModel.ShortPlanName, mainViewModel.PlanKey));
+                lv.SubItems.Add(mainViewModel.BuildActivity);
+                lv.SubItems.Add(mainViewModel.BuildStatus);
+                lv.SubItems.Add(mainViewModel.LastBuildTime);
+                lv.SubItems.Add(mainViewModel.LastBuildDuration);
+                lv.SubItems.Add(mainViewModel.LastBuildNumber);
+                lv.SubItems.Add(mainViewModel.LastVcsRevision);
+                lv.SubItems.Add(mainViewModel.SuccessfulTestCount);
+                lv.SubItems.Add(mainViewModel.FailedTestCount);
                 buildsListView.Items.Add(lv);
             }
         }
 
         private void ListViewDoubleClick(object sender, EventArgs e)
         {
-            if (buildsListView.SelectedItems.Count > 0 && buildsListView.SelectedItems[0].SubItems.Count > 3)
+            if (buildsListView.SelectedItems.Count > 0)
             {
-                var listViewSubItem = buildsListView.SelectedItems[0].SubItems[2];
+                var selectedItem = buildsListView.SelectedItems[0];
 
-                if (listViewSubItem != null && listViewSubItem.Tag != null)
+                if (selectedItem != null && selectedItem.Tag != null)
                 {
-                    var planKey = listViewSubItem.Tag.ToString();
-                    var buildData = _lastBuildData ?? new List<MainViewModel>();
-                    var buildDatum = buildData.FirstOrDefault(d => d.PlanKey == planKey);
+                    var mainViewModel = selectedItem.Tag as MainViewModel;
 
-                    if (buildDatum != null)
-                    {
-                        LaunchBrowser(buildDatum.LatestResultUrl);
-                    }
+                    if (mainViewModel != null)
+                        LaunchBrowser(mainViewModel.LatestResultUrl);
                 }
             }
             
@@ -329,6 +330,46 @@ namespace BambooTray.App
         private void UpdateTimerTick(object sender, EventArgs e)
         {
             RefreshBuilds();
+        }
+    }
+
+    internal class PreserveSelectedItemGuard : IDisposable
+    {
+        private readonly ListView _listView;
+        private readonly List<string> _selectedKeys;
+
+        public PreserveSelectedItemGuard(ListView listView)
+        {
+            _listView = listView;
+
+            if (listView.SelectedItems.Count > 0)
+            {
+                _selectedKeys = listView.SelectedItems.Cast<ListViewItem>()
+                    .Where<ListViewItem>(item => item.Tag is MainViewModel)
+                    .Select(item => ((MainViewModel) item.Tag).PlanKey).ToList();
+            }
+            else
+            {
+                _selectedKeys = new List<string>();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_selectedKeys.Count == 0)
+                return;
+
+            var itemsToSelect =
+                _listView.Items.Cast<ListViewItem>()
+                    .Where(
+                        item => item.Tag is MainViewModel && _selectedKeys.Contains(((MainViewModel) item.Tag).PlanKey));
+
+            foreach (var listViewItem in itemsToSelect)
+            {
+                _listView.FocusedItem = listViewItem;
+                listViewItem.Selected = true;
+                listViewItem.EnsureVisible();
+            }
         }
     }
 }

--- a/BambooTray.App/MainWindow.cs
+++ b/BambooTray.App/MainWindow.cs
@@ -309,21 +309,26 @@ namespace BambooTray.App
             Application.Exit();
         }
 
-        private void MainFormClosing(object sender, FormClosingEventArgs e)
+        protected override void OnFormClosing(FormClosingEventArgs e)
         {
             if (!_applicationIsExiting)
             {
                 Hide();
                 e.Cancel = true;
             }
+
+            base.OnFormClosing(e);
         }
 
-        private void NotifyIconClick(object sender, EventArgs e)
+        private void NotifyIconClick(object sender, MouseEventArgs e)
         {
-            // When tray icon is clicked, show main window and bring to front
-            Show();
-            Activate();
-            BringToFront();
+            if (e.Button == MouseButtons.Left)
+            {
+                // When tray icon is clicked, show main window and bring to front
+                Show();
+                Activate();
+                BringToFront();
+            }
         }
 
         private void BuildIconTimerTick(object sender, EventArgs e)

--- a/BambooTray.App/MainWindow.cs
+++ b/BambooTray.App/MainWindow.cs
@@ -227,7 +227,7 @@ namespace BambooTray.App
                             : (string.IsNullOrEmpty(p.BuildStatus) ? "Offline" : p.BuildStatus)
                 };
                 lv.SubItems.Add(p.ProjectName);
-                lv.SubItems.Add(p.PlanKey);
+                lv.SubItems.Add(string.Format("{0}  ({1})", p.PlanName, p.PlanKey));
                 lv.SubItems.Add(p.BuildActivity);
                 lv.SubItems.Add(p.BuildStatus);
                 lv.SubItems.Add(p.LastBuildTime);

--- a/BambooTray.App/MainWindow.resx
+++ b/BambooTray.App/MainWindow.resx
@@ -123,6 +123,9 @@
   <metadata name="notifyIcon.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>350, 17</value>
   </metadata>
+  <metadata name="contextMenuTray.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>682, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="notifyIcon.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/BambooTray.App/MainWindow.resx
+++ b/BambooTray.App/MainWindow.resx
@@ -1799,7 +1799,7 @@
   <metadata name="mainViewModelBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>132, 17</value>
   </metadata>
-  <data name="$Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAUAEBAAAAEAIABoBAAAVgAAACAgAAABACAAqBAAAL4EAAAwMAAAAQAgAKglAABmFQAAQEAAAAEA
         IAAoQgAADjsAAICAAAABACAAKAgBADZ9AAAoAAAAEAAAACAAAAABACAAAAAAAAAEAAAAAAAAAAAAAAAA

--- a/BambooTray.App/ModelBuilders/MainViewModelBuilder.cs
+++ b/BambooTray.App/ModelBuilders/MainViewModelBuilder.cs
@@ -16,12 +16,17 @@ namespace BambooTray.App.ModelBuilders
                 lastResultDetail = lastResult.Detail;
             }
 
+            var planSummaryUrl = string.Format("{0}/browse/{1}", server.Address.TrimEnd('/'), plan.Key);
+
             return new MainViewModel
                        {
                            ServerName = string.IsNullOrEmpty(server.Name) ? server.Address : server.Name,
                            ProjectName = plan.ProjectName,
                            PlanKey = plan.Key,
                            PlanName = plan.Name,
+                           ShortPlanName = plan.ShortName,
+                           PlanSummaryUrl = planSummaryUrl,
+                           LatestResultUrl = string.Concat(planSummaryUrl, "/latest"),
                            BuildActivity = plan.IsActive ? "Building" : "Sleeping",
                            BuildActive = plan.IsActive,
                            BuildStatus = lastResult != null ? lastResult.State : string.Empty,

--- a/BambooTray.App/ModelBuilders/MainViewModelBuilder.cs
+++ b/BambooTray.App/ModelBuilders/MainViewModelBuilder.cs
@@ -21,6 +21,7 @@ namespace BambooTray.App.ModelBuilders
                            ServerName = string.IsNullOrEmpty(server.Name) ? server.Address : server.Name,
                            ProjectName = plan.ProjectName,
                            PlanKey = plan.Key,
+                           PlanName = plan.Name,
                            BuildActivity = plan.IsActive ? "Building" : "Sleeping",
                            BuildActive = plan.IsActive,
                            BuildStatus = lastResult != null ? lastResult.State : string.Empty,

--- a/BambooTray.App/Models/MainViewModel.cs
+++ b/BambooTray.App/Models/MainViewModel.cs
@@ -10,6 +10,12 @@
 
         public string PlanName { get; set; }
 
+        public string ShortPlanName { get; set; }
+
+        public string PlanSummaryUrl { get; set; }
+
+        public string LatestResultUrl { get; set; }
+
         public string BuildActivity { get; set; }
 
         public bool BuildActive { get; set; }

--- a/BambooTray.App/Models/MainViewModel.cs
+++ b/BambooTray.App/Models/MainViewModel.cs
@@ -8,6 +8,8 @@
 
         public string PlanKey { get; set; }
 
+        public string PlanName { get; set; }
+
         public string BuildActivity { get; set; }
 
         public bool BuildActive { get; set; }

--- a/BambooTray.App/PreferencesWindow.Designer.cs
+++ b/BambooTray.App/PreferencesWindow.Designer.cs
@@ -28,160 +28,245 @@
         /// </summary>
         private void InitializeComponent()
         {
-            components = new System.ComponentModel.Container();
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PreferencesWindow));
-            preferencesTabControl = new System.Windows.Forms.TabControl();
-            buildsTabPage = new System.Windows.Forms.TabPage();
-            groupBox2 = new System.Windows.Forms.GroupBox();
-            buildPlansListView = new System.Windows.Forms.ListView();
-            groupBox1 = new System.Windows.Forms.GroupBox();
-            serversListBox = new System.Windows.Forms.ListBox();
-            serverViewModelBindingSource = new System.Windows.Forms.BindingSource(components);
-            addServerButton = new System.Windows.Forms.Button();
-            configureServerButton = new System.Windows.Forms.Button();
-            removeServerButton = new System.Windows.Forms.Button();
-            generalTabPage = new System.Windows.Forms.TabPage();
-            preferencesTabControl.SuspendLayout();
-            buildsTabPage.SuspendLayout();
-            groupBox2.SuspendLayout();
-            groupBox1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(serverViewModelBindingSource)).BeginInit();
-            SuspendLayout();
+            this.preferencesTabControl = new System.Windows.Forms.TabControl();
+            this.buildsTabPage = new System.Windows.Forms.TabPage();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.buildPlansListView = new System.Windows.Forms.ListView();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.serversListBox = new System.Windows.Forms.ListBox();
+            this.serverViewModelBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.addServerButton = new System.Windows.Forms.Button();
+            this.configureServerButton = new System.Windows.Forms.Button();
+            this.removeServerButton = new System.Windows.Forms.Button();
+            this.generalTabPage = new System.Windows.Forms.TabPage();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.checkboxEnableBalloonNotifications = new System.Windows.Forms.CheckBox();
+            this.numericPollTime = new System.Windows.Forms.NumericUpDown();
+            this.numericBalloonTooltipTimeout = new System.Windows.Forms.NumericUpDown();
+            this.preferencesTabControl.SuspendLayout();
+            this.buildsTabPage.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.serverViewModelBindingSource)).BeginInit();
+            this.panel1.SuspendLayout();
+            this.generalTabPage.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericPollTime)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericBalloonTooltipTimeout)).BeginInit();
+            this.SuspendLayout();
             // 
             // preferencesTabControl
             // 
-            preferencesTabControl.Controls.Add(buildsTabPage);
-            preferencesTabControl.Controls.Add(generalTabPage);
-            preferencesTabControl.Location = new System.Drawing.Point(12, 12);
-            preferencesTabControl.Name = "preferencesTabControl";
-            preferencesTabControl.SelectedIndex = 0;
-            preferencesTabControl.Size = new System.Drawing.Size(626, 283);
-            preferencesTabControl.SizeMode = System.Windows.Forms.TabSizeMode.FillToRight;
-            preferencesTabControl.TabIndex = 0;
+            this.preferencesTabControl.Controls.Add(this.buildsTabPage);
+            this.preferencesTabControl.Controls.Add(this.generalTabPage);
+            this.preferencesTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.preferencesTabControl.Location = new System.Drawing.Point(0, 0);
+            this.preferencesTabControl.Name = "preferencesTabControl";
+            this.preferencesTabControl.SelectedIndex = 0;
+            this.preferencesTabControl.Size = new System.Drawing.Size(649, 307);
+            this.preferencesTabControl.SizeMode = System.Windows.Forms.TabSizeMode.FillToRight;
+            this.preferencesTabControl.TabIndex = 0;
             // 
             // buildsTabPage
             // 
-            buildsTabPage.BackColor = System.Drawing.SystemColors.Control;
-            buildsTabPage.Controls.Add(groupBox2);
-            buildsTabPage.Controls.Add(groupBox1);
-            buildsTabPage.Location = new System.Drawing.Point(4, 22);
-            buildsTabPage.Name = "buildsTabPage";
-            buildsTabPage.Padding = new System.Windows.Forms.Padding(3);
-            buildsTabPage.Size = new System.Drawing.Size(618, 257);
-            buildsTabPage.TabIndex = 1;
-            buildsTabPage.Text = "Builds";
+            this.buildsTabPage.BackColor = System.Drawing.SystemColors.Control;
+            this.buildsTabPage.Controls.Add(this.groupBox2);
+            this.buildsTabPage.Controls.Add(this.groupBox1);
+            this.buildsTabPage.Location = new System.Drawing.Point(4, 22);
+            this.buildsTabPage.Name = "buildsTabPage";
+            this.buildsTabPage.Padding = new System.Windows.Forms.Padding(3, 10, 3, 3);
+            this.buildsTabPage.Size = new System.Drawing.Size(641, 281);
+            this.buildsTabPage.TabIndex = 1;
+            this.buildsTabPage.Text = "Builds";
             // 
             // groupBox2
             // 
-            groupBox2.Controls.Add(buildPlansListView);
-            groupBox2.Location = new System.Drawing.Point(312, 15);
-            groupBox2.Name = "groupBox2";
-            groupBox2.Size = new System.Drawing.Size(300, 228);
-            groupBox2.TabIndex = 7;
-            groupBox2.TabStop = false;
-            groupBox2.Text = "Build Plans";
+            this.groupBox2.Controls.Add(this.buildPlansListView);
+            this.groupBox2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.groupBox2.Location = new System.Drawing.Point(269, 10);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(369, 268);
+            this.groupBox2.TabIndex = 7;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Build Plans";
             // 
             // buildPlansListView
             // 
-            buildPlansListView.CheckBoxes = true;
-            buildPlansListView.FullRowSelect = true;
-            buildPlansListView.Location = new System.Drawing.Point(7, 20);
-            buildPlansListView.Name = "buildPlansListView";
-            buildPlansListView.Size = new System.Drawing.Size(287, 172);
-            buildPlansListView.TabIndex = 0;
-            buildPlansListView.UseCompatibleStateImageBehavior = false;
-            buildPlansListView.View = System.Windows.Forms.View.List;
-            buildPlansListView.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(BuildPlansListViewItemChecked);
+            this.buildPlansListView.CheckBoxes = true;
+            this.buildPlansListView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.buildPlansListView.FullRowSelect = true;
+            this.buildPlansListView.Location = new System.Drawing.Point(3, 16);
+            this.buildPlansListView.Name = "buildPlansListView";
+            this.buildPlansListView.Size = new System.Drawing.Size(363, 249);
+            this.buildPlansListView.TabIndex = 0;
+            this.buildPlansListView.UseCompatibleStateImageBehavior = false;
+            this.buildPlansListView.View = System.Windows.Forms.View.List;
+            this.buildPlansListView.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(this.BuildPlansListViewItemChecked);
             // 
             // groupBox1
             // 
-            groupBox1.Controls.Add(serversListBox);
-            groupBox1.Controls.Add(addServerButton);
-            groupBox1.Controls.Add(configureServerButton);
-            groupBox1.Controls.Add(removeServerButton);
-            groupBox1.Location = new System.Drawing.Point(6, 15);
-            groupBox1.Name = "groupBox1";
-            groupBox1.Size = new System.Drawing.Size(300, 228);
-            groupBox1.TabIndex = 6;
-            groupBox1.TabStop = false;
-            groupBox1.Text = "Build Servers";
+            this.groupBox1.Controls.Add(this.serversListBox);
+            this.groupBox1.Controls.Add(this.panel1);
+            this.groupBox1.Dock = System.Windows.Forms.DockStyle.Left;
+            this.groupBox1.Location = new System.Drawing.Point(3, 10);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(266, 268);
+            this.groupBox1.TabIndex = 6;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Build Servers";
             // 
             // serversListBox
             // 
-            serversListBox.DataSource = serverViewModelBindingSource;
-            serversListBox.DisplayMember = "Name";
-            serversListBox.FormattingEnabled = true;
-            serversListBox.Location = new System.Drawing.Point(6, 19);
-            serversListBox.Name = "serversListBox";
-            serversListBox.Size = new System.Drawing.Size(288, 173);
-            serversListBox.TabIndex = 6;
-            serversListBox.ValueMember = "Address";
+            this.serversListBox.DataSource = this.serverViewModelBindingSource;
+            this.serversListBox.DisplayMember = "Name";
+            this.serversListBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.serversListBox.FormattingEnabled = true;
+            this.serversListBox.Location = new System.Drawing.Point(3, 16);
+            this.serversListBox.Name = "serversListBox";
+            this.serversListBox.Size = new System.Drawing.Size(260, 213);
+            this.serversListBox.TabIndex = 6;
+            this.serversListBox.ValueMember = "Address";
             // 
             // serverViewModelBindingSource
             // 
-            serverViewModelBindingSource.DataSource = typeof(BambooTray.Domain.Settings.Server);
+            this.serverViewModelBindingSource.DataSource = typeof(BambooTray.Domain.Settings.Server);
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.addServerButton);
+            this.panel1.Controls.Add(this.configureServerButton);
+            this.panel1.Controls.Add(this.removeServerButton);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.panel1.Location = new System.Drawing.Point(3, 229);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(260, 36);
+            this.panel1.TabIndex = 9;
             // 
             // addServerButton
             // 
-            addServerButton.Location = new System.Drawing.Point(28, 199);
-            addServerButton.Name = "addServerButton";
-            addServerButton.Size = new System.Drawing.Size(75, 23);
-            addServerButton.TabIndex = 2;
-            addServerButton.Text = "&Add";
-            addServerButton.UseVisualStyleBackColor = true;
-            addServerButton.Click += new System.EventHandler(AddServerButtonClick);
+            this.addServerButton.Location = new System.Drawing.Point(10, 6);
+            this.addServerButton.Name = "addServerButton";
+            this.addServerButton.Size = new System.Drawing.Size(75, 23);
+            this.addServerButton.TabIndex = 6;
+            this.addServerButton.Text = "&Add";
+            this.addServerButton.UseVisualStyleBackColor = true;
+            this.addServerButton.Click += new System.EventHandler(this.AddServerButtonClick);
             // 
             // configureServerButton
             // 
-            configureServerButton.Location = new System.Drawing.Point(190, 199);
-            configureServerButton.Name = "configureServerButton";
-            configureServerButton.Size = new System.Drawing.Size(75, 23);
-            configureServerButton.TabIndex = 5;
-            configureServerButton.Text = "&Configure";
-            configureServerButton.UseVisualStyleBackColor = true;
-            configureServerButton.Click += new System.EventHandler(ConfigureServerButtonClick);
+            this.configureServerButton.Location = new System.Drawing.Point(172, 6);
+            this.configureServerButton.Name = "configureServerButton";
+            this.configureServerButton.Size = new System.Drawing.Size(75, 23);
+            this.configureServerButton.TabIndex = 8;
+            this.configureServerButton.Text = "&Configure";
+            this.configureServerButton.UseVisualStyleBackColor = true;
+            this.configureServerButton.Click += new System.EventHandler(this.ConfigureServerButtonClick);
             // 
             // removeServerButton
             // 
-            removeServerButton.Location = new System.Drawing.Point(109, 199);
-            removeServerButton.Name = "removeServerButton";
-            removeServerButton.Size = new System.Drawing.Size(75, 23);
-            removeServerButton.TabIndex = 4;
-            removeServerButton.Text = "&Remove";
-            removeServerButton.UseVisualStyleBackColor = true;
-            removeServerButton.Click += new System.EventHandler(RemoveServerButtonClick);
+            this.removeServerButton.Location = new System.Drawing.Point(91, 6);
+            this.removeServerButton.Name = "removeServerButton";
+            this.removeServerButton.Size = new System.Drawing.Size(75, 23);
+            this.removeServerButton.TabIndex = 7;
+            this.removeServerButton.Text = "&Remove";
+            this.removeServerButton.UseVisualStyleBackColor = true;
+            this.removeServerButton.Click += new System.EventHandler(this.RemoveServerButtonClick);
             // 
             // generalTabPage
             // 
-            generalTabPage.BackColor = System.Drawing.SystemColors.Control;
-            generalTabPage.Location = new System.Drawing.Point(4, 22);
-            generalTabPage.Name = "generalTabPage";
-            generalTabPage.Padding = new System.Windows.Forms.Padding(3);
-            generalTabPage.Size = new System.Drawing.Size(618, 257);
-            generalTabPage.TabIndex = 0;
-            generalTabPage.Text = "General";
+            this.generalTabPage.BackColor = System.Drawing.SystemColors.Control;
+            this.generalTabPage.Controls.Add(this.numericBalloonTooltipTimeout);
+            this.generalTabPage.Controls.Add(this.numericPollTime);
+            this.generalTabPage.Controls.Add(this.checkboxEnableBalloonNotifications);
+            this.generalTabPage.Controls.Add(this.label2);
+            this.generalTabPage.Controls.Add(this.label1);
+            this.generalTabPage.Location = new System.Drawing.Point(4, 22);
+            this.generalTabPage.Name = "generalTabPage";
+            this.generalTabPage.Padding = new System.Windows.Forms.Padding(3);
+            this.generalTabPage.Size = new System.Drawing.Size(641, 281);
+            this.generalTabPage.TabIndex = 0;
+            this.generalTabPage.Text = "General";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 22);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(113, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Poll Time (in seconds):";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 66);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(181, 13);
+            this.label2.TabIndex = 1;
+            this.label2.Text = "Balloon Tooltip Timeout (in seconds):";
+            // 
+            // checkboxEnableBalloonNotifications
+            // 
+            this.checkboxEnableBalloonNotifications.AutoSize = true;
+            this.checkboxEnableBalloonNotifications.Location = new System.Drawing.Point(12, 42);
+            this.checkboxEnableBalloonNotifications.Name = "checkboxEnableBalloonNotifications";
+            this.checkboxEnableBalloonNotifications.Size = new System.Drawing.Size(158, 17);
+            this.checkboxEnableBalloonNotifications.TabIndex = 2;
+            this.checkboxEnableBalloonNotifications.Text = "Enable Balloon Notifications";
+            this.checkboxEnableBalloonNotifications.UseVisualStyleBackColor = true;
+            // 
+            // numericPollTime
+            // 
+            this.numericPollTime.Location = new System.Drawing.Point(199, 22);
+            this.numericPollTime.Maximum = new decimal(new int[] {
+            60,
+            0,
+            0,
+            0});
+            this.numericPollTime.Name = "numericPollTime";
+            this.numericPollTime.Size = new System.Drawing.Size(51, 20);
+            this.numericPollTime.TabIndex = 5;
+            // 
+            // numericBalloonTooltipTimeout
+            // 
+            this.numericBalloonTooltipTimeout.Location = new System.Drawing.Point(199, 66);
+            this.numericBalloonTooltipTimeout.Maximum = new decimal(new int[] {
+            60,
+            0,
+            0,
+            0});
+            this.numericBalloonTooltipTimeout.Name = "numericBalloonTooltipTimeout";
+            this.numericBalloonTooltipTimeout.Size = new System.Drawing.Size(51, 20);
+            this.numericBalloonTooltipTimeout.TabIndex = 6;
             // 
             // PreferencesWindow
             // 
-            AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(649, 307);
-            Controls.Add(preferencesTabControl);
-            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            Icon = ((System.Drawing.Icon)(resources.GetObject("$Icon")));
-            MaximizeBox = false;
-            MinimizeBox = false;
-            Name = "PreferencesWindow";
-            ShowInTaskbar = false;
-            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            Text = "Bamboo Tray Preferences";
-            TopMost = true;
-            preferencesTabControl.ResumeLayout(false);
-            buildsTabPage.ResumeLayout(false);
-            groupBox2.ResumeLayout(false);
-            groupBox1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(serverViewModelBindingSource)).EndInit();
-            ResumeLayout(false);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(649, 307);
+            this.Controls.Add(this.preferencesTabControl);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "PreferencesWindow";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Bamboo Tray Preferences";
+            this.TopMost = true;
+            this.preferencesTabControl.ResumeLayout(false);
+            this.buildsTabPage.ResumeLayout(false);
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.serverViewModelBindingSource)).EndInit();
+            this.panel1.ResumeLayout(false);
+            this.generalTabPage.ResumeLayout(false);
+            this.generalTabPage.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.numericPollTime)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericBalloonTooltipTimeout)).EndInit();
+            this.ResumeLayout(false);
 
         }
 
@@ -190,13 +275,19 @@
         private System.Windows.Forms.TabControl preferencesTabControl;
         private System.Windows.Forms.TabPage generalTabPage;
         private System.Windows.Forms.TabPage buildsTabPage;
-        private System.Windows.Forms.Button removeServerButton;
-        private System.Windows.Forms.Button addServerButton;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.ListBox serversListBox;
-        private System.Windows.Forms.Button configureServerButton;
         private System.Windows.Forms.BindingSource serverViewModelBindingSource;
         private System.Windows.Forms.ListView buildPlansListView;
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Button addServerButton;
+        private System.Windows.Forms.Button configureServerButton;
+        private System.Windows.Forms.Button removeServerButton;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.CheckBox checkboxEnableBalloonNotifications;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.NumericUpDown numericBalloonTooltipTimeout;
+        private System.Windows.Forms.NumericUpDown numericPollTime;
     }
 }

--- a/BambooTray.App/PreferencesWindow.cs
+++ b/BambooTray.App/PreferencesWindow.cs
@@ -23,6 +23,45 @@ namespace BambooTray.App
             _settingsService = settingsService;
             PopulateServerListView();
             serversListBox.SelectedIndexChanged += ServersListBoxOnSelectedIndexChanged;
+            PopulateGeneralSettings();
+        }
+
+        private void PopulateGeneralSettings()
+        {
+            TraySettings traySettings = _settingsService.TraySettings;
+
+            numericPollTime.Value = ToSeconds(traySettings.PollTime, (int)numericPollTime.Minimum, (int)numericPollTime.Maximum);
+            numericBalloonTooltipTimeout.Value = ToSeconds(traySettings.BalloonToolTipTimeOut, (int)numericBalloonTooltipTimeout.Minimum, (int)numericBalloonTooltipTimeout.Maximum);
+            checkboxEnableBalloonNotifications.Checked = traySettings.EnableBaloonNotifications;
+
+            numericPollTime.ValueChanged += (sender, args) =>
+            {
+                traySettings.PollTime = ToMilliseconds((int) numericPollTime.Value);
+                _settingsService.SaveTraySettings();
+            };
+
+            numericBalloonTooltipTimeout.ValueChanged += (sender, args) =>
+            {
+                traySettings.BalloonToolTipTimeOut = ToMilliseconds((int) numericBalloonTooltipTimeout.Value);
+                _settingsService.SaveTraySettings();
+            };
+
+            checkboxEnableBalloonNotifications.CheckedChanged += (sender, args) =>
+            {
+                traySettings.EnableBaloonNotifications = checkboxEnableBalloonNotifications.Checked;
+                _settingsService.SaveTraySettings();
+            };
+        }
+
+        private int ToSeconds(int milliseconds, int min, int max)
+        {
+            int timeInSeconds = milliseconds/1000;
+            return Math.Min(Math.Max(timeInSeconds, min), max);
+        }
+
+        private int ToMilliseconds(int seconds)
+        {
+            return seconds*1000;
         }
 
         private static Server GetServerFromViewModel(ServerViewModel serverViewModel)

--- a/BambooTray.App/PreferencesWindow.resx
+++ b/BambooTray.App/PreferencesWindow.resx
@@ -121,7 +121,7 @@
     <value>17, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="$Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAUAEBAAAAEAIABoBAAAVgAAACAgAAABACAAqBAAAL4EAAAwMAAAAQAgAKglAABmFQAAQEAAAAEA
         IAAoQgAADjsAAICAAAABACAAKAgBADZ9AAAoAAAAEAAAACAAAAABACAAAAAAAAAEAAAAAAAAAAAAAAAA


### PR DESCRIPTION
Updated: Added another commit to my original pull request to tweak the plan name to use the short description instead. Also added a double-click event handler to launch the latest build results in a browser.


Previously the plan key was displayed in the grid. I had a hard time matching the plan key with the plan name displayed on the Bamboo web page. This change adds the plan name with the key in parentheses.